### PR TITLE
Update Dependabot config to exclude docs directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -42,4 +42,5 @@ updates:
   cooldown:
     default-days: 1
     exclude: ["*"]
-  versioning-strategy: increase
+  exclude-paths:
+    - "docs/**"


### PR DESCRIPTION
Exclude 'docs/**' from Dependabot updates.